### PR TITLE
Fix Makefile run target

### DIFF
--- a/landkreise/Makefile
+++ b/landkreise/Makefile
@@ -1,4 +1,6 @@
 build:
 	sudo docker build -t crawler .
 run:
-	sudo docker run -it --mount type=bind,src="$(pwd)",destination=/landkreise crawler
+	sudo docker run -it --mount type=bind,src="$$(pwd)",destination=/landkreise crawler
+
+.PHONY: build run


### PR DESCRIPTION
The current run target does not properly spawn a subshell which results
in an "invalid mount config" when `docker run` tries to
inteprates the `--volume` parameter. Hence, this commit prevents `make` from
trying to expand the string to a variable in the first place.
(fixes: corona-zahlen-landkreis/corona_landkreis_fallzahlen_scraping#67)

It also declares both targets as `.PHONY` to prevents issues in the case of the creation of files with the same names.