### PR TITLE
Add a requirements.txt for python dependencies

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -47,23 +47,20 @@ community data (aggregates to distrcit - hopefully):
 ```landkreise/data/0<districtId>/<communityId>.csv```
 
 ### Requirements:
-  * Python3
-    * requests (often included)
-    * CacheControl[filecache] (persistent cache does not work yet)
-      * lockfile
-    * beautiful soup 4
+* Python3
+* Dependencies from `requirements.txt` which can be install as follows:
 
-pip3 line:
-```
-pip3 install requests bs4 cachecontrol[filecache] lockfile
-```
+  - by using pip:
+  ```
+  pip3 install -r requirements.txt
+  ```
 
-Debian/Ubuntu packages:
-```
-  sudo apt-get install python3 python3-bs4 python3-cachecontrol python3-lockfile
-```
+  - by using Debian/Ubuntu packages:
+  ```
+  sudo apt install python3 python3-bs4 python3-cachecontrol python3-lockfile python3-tqdm
+  ```
 
-  * Makefile for Docker container also exists
+Alternatively, you can use the Dockerfile to build a Docker container which has everything already installed.
 
 ### Writing / Mainting a scraper
 

--- a/README.md
+++ b/README.md
@@ -54,24 +54,21 @@ community data (aggregates to distrcit - hopefully):
 ```landkreise/data/0<districtId>/<communityId>.csv```
 
 ### Requirements:
-  * Python3
-    * requests (often included)
-    * CacheControl[filecache] (persistent cache does not work yet)
-      * lockfile
-    * beautiful soup 4
-    * running all scrapers tqdm
 
-pip3 line:
-```
-pip3 install requests bs4 cachecontrol[filecache] lockfile tqdm
-```
+* Python3
+* Dependencies from `requirements.txt` which can be install as follows:
 
-Debian/Ubuntu packages:
-```
-  sudo apt-get install python3 python3-bs4 python3-cachecontrol python3-lockfile python3-tqdm
-```
+  - by using pip:
+  ```
+  pip3 install -r requirements.txt
+  ```
 
-  * Makefile for Docker container also exists
+  - by using Debian/Ubuntu packages:
+  ```
+  sudo apt install python3 python3-bs4 python3-cachecontrol python3-lockfile python3-tqdm
+  ```
+
+Alternatively, you can use the Dockerfile to build a Docker container which has everything already installed.
 
 ### Writing / Mainting a scraper
 

--- a/landkreise/Dockerfile
+++ b/landkreise/Dockerfile
@@ -30,6 +30,7 @@ VOLUME /landkreise
 # - add ~/.local/bin for pip --user
 ENV PATH="/home/corona/.local/bin:${PATH}"
 # - install dependencies
-RUN pip3 install --user bs4 requests cachecontrol[filecache] lockfile tqdm
+ADD requirements.txt /tmp/
+RUN pip3 install --user --requirement /tmp/requirements.txt
 
 CMD bash

--- a/landkreise/requirements.txt
+++ b/landkreise/requirements.txt
@@ -1,0 +1,5 @@
+bs4==0.0.1
+CacheControl==0.12.6
+lockfile==0.12.2
+requests==2.24.0
+tqdm==4.46.1


### PR DESCRIPTION
This commit introduces a `requirements.txt` to define
all dependencies required to build the crawler at one
central point.
The `Dockerfile` and the documentation will also be adapted
accordingly.

(fixes: corona-zahlen-landkreis/corona_landkreis_fallzahlen_scraping#63)